### PR TITLE
FIX: Issue #5

### DIFF
--- a/src/microgp/genoperator.py
+++ b/src/microgp/genoperator.py
@@ -25,7 +25,7 @@
 # limitations under the License.
 
 import inspect
-from collections import Callable
+from collections.abc import Callable
 
 from .individual import Individual
 


### PR DESCRIPTION
Python 3.10 support. Since python 3.5, `Callable` is available from `collections.abc`